### PR TITLE
ラジオボタン「NO STARTED」「DONE」の番号整理

### DIFF
--- a/script.js
+++ b/script.js
@@ -53,11 +53,11 @@ const showTodo = () => {
     return todo.status === filter;
   });
 
-  filteredList.forEach((todo) => {
+  filteredList.forEach((todo, index) => {
     const tr = document.createElement("tr");
 
     const id = document.createElement("td");
-    id.innerText = todo.id;
+    id.innerText = index + 1;
     tr.appendChild(id);
 
     const title = document.createElement("td");


### PR DESCRIPTION
<!-- この内容を全てPRに貼り付ける -->
# ラジオボタン「NO STARTED」「DONE」の番号整理

## 実施内容

### ラジオボタン「NO STARTED」「DONE」どの状態でも番号が整理されている状態にする
## 関連するタスク

## 前提条件
1. 初期表示時、３つのタスクが追加された状態
2. ラジオボタンが「All」「Not Started 」「Done」の３つが初期表示されている
3. 初期表示（ラジオボタンが「All」）の時、追加されている３つのタスクの状態表示が全て「Not Started 」で表示されている

## テストケース１：ラジオボタン「NO STARTED」時の動作確認
### 手順
1.  ラジオボタンを「Not Started 」に切り替える
2. ラジオボタン「Not Started 」の時に、入力欄にaaaと入力
3. 日付選択欄の日付を2025/5/1と選択
4. 追加ボタンを押下する
5. ID番号２のタスクの「×」ボタンを押下する
6. ID番号１のタスクの状態表示を「DONE」に切り替える

## 期待結果
1. ラジオボタンを「Not Started 」に切り替えると、３つのタスクが１．２．３と番号順に表示される
2. タスク追加時にID番号４が追加される
3. ID番号２が削除され、残っている３つのタスクのID番号が１．２．３と整理される
4. ID番号１のタスクの状態表示を「DONE」に切り替えると、ID番号１が画面上から削除され、残った２つのタスクのID番号が１．２と整理される

## 結果
期待結果のとおり

## テストケース２：ラジオボタン「DONE」時の動作確認
### 手順
1. ラジオボタンを「All」時に３つのタスクの状態を「DONE」に切り替え、ラジオボタンにあっても「DONE」に切り替える
2. ラジオボタン「DONE」の時に、入力欄にaaaと入力
3. 日付選択欄の日付を2025/5/1と選択
4.  追加ボタンを押下する
5. ID番号２のタスクの「×」ボタンを押下する
6. ID番号１のタスクの状態表示を「Not Started」に切り替える

## 期待結果
1. ラジオボタンを「DONE 」に切り替えると、３つのタスクが１．２．３と番号順に表示される
2. タスク追加時にID番号４が追加される
3. ID番号２が削除され、残っている３つのタスクのID番号が１．２．３と整理される
4. ID番号１のタスクの状態表示を「Not Started」に切り替えると、ID番号１が画面上から削除され、残った２つのタスクのID番号が１．２と整理される

## 結果
期待結果のとおり

## テストケース３：ラジオボタン「All」時の動作確認
### 手順
1. ラジオボタンを「DONE 」に切り替える
2. ラジオボタン「DONE 」の時に、入力欄にaaaと入力
3. 日付選択欄の日付を2025/5/1と選択
4. 追加ボタンを押下する
5. ラジオボタンを「Not Started」に切り替える
6.  ラジオボタン「Not Started」の時に、入力欄にaaaと入力
7. 日付選択欄の日付を2025/5/1と選択
8.  追加ボタンを押下する
9. ラジオボタンを「All」に切り替える
10. ID番号３の「×」ボタンを押下する
11. ID番号２の状態表示を「DONE」に切り替える

## 期待結果
1. ラジオボタン「DONE」時にID番号１のタスクが追加される
2. ラジオボタン「Not Started 」時にID番号４のタスクが追加される
3. ラジオボタンを「All」に切り替えるとラジオボタンを「DONE」時に追加したID番号１のタスクがID番号４で追加されており、ラジオボタンを「Not Started」時に追加したID番号４のタスクがID番号５で追加されている
4. ID番号３のタスクが削除され、残った４つのタスクのID番号が１．２．３．４と整理されている

## 結果
期待結果のとおり




## 確認事項

<!-- 問題点は可能な限り対応して難しい場合は補足に記載する -->

- [ ]  動作確認をしたか？
- [ ]  新たにエラーは発生していないか？
- [ ]  merge後に新たなTaskやIssueは発生するか？（発生する場合はTaskを作成したか？）

## 補足

<!-- 補足すべきことがあれば書く -->